### PR TITLE
Feat(save_values): Save current values when saving the configuration

### DIFF
--- a/src/rqt_ez_publisher/ez_publisher_plugin.py
+++ b/src/rqt_ez_publisher/ez_publisher_plugin.py
@@ -95,6 +95,14 @@ class EzPublisherPlugin(Plugin):
                 slider_setting = settings['settings'][slider.get_text()]
                 slider.set_range(
                     [slider_setting['min'], slider_setting['max']])
+                if(type(slider).__name__ == 'DoubleValueWidget'):
+                    slider._slider.setValue(slider.value_to_slider(slider_setting['value']))
+                elif(type(slider).__name__ == 'IntValueWidget' or type(slider).__name__ == 'UIntValueWidget'):
+                    slider._slider.setValue(slider_setting['value'])
+                elif(type(slider).__name__ == 'StringValueWidget'):
+                    slider._line_edit.setText(slider_setting['value'])
+                elif(type(slider).__name__ == 'BoolValueWidget'):
+                    slider._check_box.setChecked(slider_setting['value'])
 
                 slider.set_is_repeat(slider_setting['is_repeat'])
             except KeyError as e:
@@ -103,6 +111,11 @@ class EzPublisherPlugin(Plugin):
             settings['publish_interval'])
 
     def save_to_dict(self):
+        slider_types_list = ['DoubleValueWidget',
+                             'IntValueWidget',
+                             'UIntValueWidget',
+                             'StringValueWidget',
+                             'BoolValueWidget']
         save_dict = {}
         save_dict['texts'] = [x.get_text() for x in self._widget.get_sliders()]
         save_dict['publish_interval'] = (
@@ -115,6 +128,9 @@ class EzPublisherPlugin(Plugin):
             save_dict['settings'][slider.get_text()]['max'] = range_max
             save_dict['settings'][slider.get_text()]['is_repeat'] = (
                 slider.is_repeat())
+            if(type(slider).__name__ in slider_types_list):
+                save_dict['settings'][slider.get_text()]['value'] = (
+                    slider.valueNow)
         return save_dict
 
     def trigger_configuration(self):

--- a/src/rqt_ez_publisher/widget/bool_value_widget.py
+++ b/src/rqt_ez_publisher/widget/bool_value_widget.py
@@ -4,12 +4,15 @@ import value_widget
 
 class BoolValueWidget(value_widget.ValueWidget):
 
+    valueNow = False
+
     def __init__(self, topic_name, attributes, array_index, publisher, parent):
         self._type = bool
         super(BoolValueWidget, self).__init__(
             topic_name, attributes, array_index, publisher, parent)
 
     def state_changed(self, state):
+        self.valueNow = self._check_box.isChecked()
         self.publish_value(self._check_box.isChecked())
 
     def setup_ui(self, name):

--- a/src/rqt_ez_publisher/widget/double_value_widget.py
+++ b/src/rqt_ez_publisher/widget/double_value_widget.py
@@ -1,7 +1,7 @@
 from python_qt_binding import QtCore
 from python_qt_binding import QtWidgets
 import value_widget
-
+from sys import float_info as float_info
 
 class DoubleValueWidget(value_widget.ValueWidget):
 
@@ -36,15 +36,15 @@ class DoubleValueWidget(value_widget.ValueWidget):
 
     def setup_ui(self, name):
         self._min_spin_box = QtWidgets.QDoubleSpinBox()
-        self._min_spin_box.setMaximum(10000)
-        self._min_spin_box.setMinimum(-10000)
+        self._min_spin_box.setMaximum(float_info.max)
+        self._min_spin_box.setMinimum(-float_info.max)
         self._min_spin_box.setValue(self.DEFAULT_MIN_VALUE)
         self._slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self._slider.setTickPosition(QtWidgets.QSlider.TicksBelow)
         self._slider.valueChanged.connect(self.slider_changed)
         self._max_spin_box = QtWidgets.QDoubleSpinBox()
-        self._max_spin_box.setMaximum(10000)
-        self._max_spin_box.setMinimum(-10000)
+        self._max_spin_box.setMaximum(float_info.max)
+        self._max_spin_box.setMinimum(-float_info.max)
         self._max_spin_box.setValue(self.DEFAULT_MAX_VALUE)
         self._lcd = QtWidgets.QLCDNumber()
         self._lcd.setMaximumHeight(self.LCD_HEIGHT)

--- a/src/rqt_ez_publisher/widget/double_value_widget.py
+++ b/src/rqt_ez_publisher/widget/double_value_widget.py
@@ -8,6 +8,7 @@ class DoubleValueWidget(value_widget.ValueWidget):
     LCD_HEIGHT = 35
     DEFAULT_MAX_VALUE = 1.0
     DEFAULT_MIN_VALUE = -1.0
+    valueNow = 0.0
 
     def __init__(self, topic_name, attributes, array_index, publisher, parent,
                  label_text=None):
@@ -19,6 +20,7 @@ class DoubleValueWidget(value_widget.ValueWidget):
     def set_value(self, value):
         self._lcd.display(value)
         self.publish_value(value)
+        self.valueNow = value
 
     def value_to_slider(self, value):
         return (value - self._min_spin_box.value()) / (

--- a/src/rqt_ez_publisher/widget/int_value_widget.py
+++ b/src/rqt_ez_publisher/widget/int_value_widget.py
@@ -6,6 +6,7 @@ import value_widget
 class IntValueWidget(value_widget.ValueWidget):
 
     LCD_HEIGHT = 35
+    valueNow = 0
 
     def __init__(self, topic_name, attributes, array_index, publisher, parent):
         self._type = int
@@ -15,6 +16,7 @@ class IntValueWidget(value_widget.ValueWidget):
     def slider_changed(self, value):
         self._lcd.display(value)
         self.publish_value(value)
+        self.valueNow = value
 
     def setup_ui(self, name, max_value=100000, min_value=-100000,
                  default_max_value=100, default_min_value=-100,

--- a/src/rqt_ez_publisher/widget/string_value_widget.py
+++ b/src/rqt_ez_publisher/widget/string_value_widget.py
@@ -4,12 +4,15 @@ import value_widget
 
 class StringValueWidget(value_widget.ValueWidget):
 
+    valueNow = ''
+
     def __init__(self, topic_name, attributes, array_index, publisher, parent):
         self._type = str
         super(StringValueWidget, self).__init__(
             topic_name, attributes, array_index, publisher, parent)
 
     def input_text(self):
+        self.valueNow = str(self._line_edit.text())
         self.publish_value(str(self._line_edit.text()))
 
     def setup_ui(self, name):


### PR DESCRIPTION
Now the values of the sliders, texts and checkboxes get stored when "save to file" is used, and get loaded when "load from file" is called.

Note: This functionality only works for the widgets in the "widget folder", namely: bool, double, int, uint and string. I do not know if there are any more, but in that case the value will not be saved and the plugin will work as before.