### PR TITLE
fix bug on saving config to a file

### DIFF
--- a/src/rqt_ez_publisher/ez_publisher_plugin.py
+++ b/src/rqt_ez_publisher/ez_publisher_plugin.py
@@ -39,8 +39,7 @@ class EzPublisherPlugin(Plugin):
     def save_to_file(self, file_path):
         try:
             f = open(file_path, 'w')
-            f.write(yaml.safe_dump(self.save_to_dict(),
-                                   encoding='utf-8', allow_unicode=True))
+            yaml.dump(self.save_to_dict(),f)
             f.close()
             rospy.loginfo('saved as %s' % file_path)
         except IOError as e:


### PR DESCRIPTION
When saving config to a file, following error has occurred, so I fixed it.

```
Traceback (most recent call last):
  File "<path>/rqt_ez_publisher/src/rqt_ez_publisher/config_dialog.py", line 58, in save_to_file
    self._plugin.save_to_file(file_path)
  File "<path>/rqt_ez_publisher/src/rqt_ez_publisher/ez_publisher_plugin.py", line 42, in save_to_file
    f.write(yaml.safe_dump(self.save_to_dict(),
TypeError: write() argument must be str, not bytes
```